### PR TITLE
修改宽度获取方式, 防止子组件溢出

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,12 @@ class MyAPP extends StatelessWidget {
         id: '$i',
         crossAxisCellCount: crossList[i],
         mainAxisCellCount: mainList[i],
-        child: Center(child: Text('$i')),
+        child: Container(
+            decoration: BoxDecoration(
+            color: Colors.primaries[i % Colors.primaries.length],
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            child: Center(child: Text('$i'))),
       ));
     }
     return StaggeredReorderableView.customer(children: children, columnNum: 4);
@@ -33,10 +38,13 @@ class MyAPP extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Example'),
         ),
-        body: SizedBox(
-          width: double.infinity,
-          height: double.infinity,
-          child: _body(),
+        body: Padding(
+          padding: const EdgeInsets.only(left: 20.0),
+          child: SizedBox(
+            width: double.infinity,
+            height: double.infinity,
+            child: _body(),
+          ),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,13 +22,17 @@ class MyAPP extends StatelessWidget {
         mainAxisCellCount: mainList[i],
         child: Container(
             decoration: BoxDecoration(
-            color: Colors.primaries[i % Colors.primaries.length],
+              color: Colors.primaries[i % Colors.primaries.length],
               borderRadius: BorderRadius.circular(8.0),
             ),
             child: Center(child: Text('$i'))),
       ));
     }
-    return StaggeredReorderableView.customer(children: children, columnNum: 4);
+    return StaggeredReorderableView.customer(
+      children: children,
+      columnNum: 4,
+      fixedCellHeight: 80,
+    );
   }
 
   @override

--- a/lib/src/cutomer_multi_child_layout_view.dart
+++ b/lib/src/cutomer_multi_child_layout_view.dart
@@ -326,11 +326,17 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                 childWhenDragging: null,
                 feedback: Material(
                   color: Colors.transparent,
-                  child: SizedBox(
-                    width: itemAll[index].crossAxisCellCount! * itemCellWidth,
-                    height: itemAll[index].mainAxisCellCount! * itemCellHeight,
-                    child: Center(
-                      child: itemAll[index].feedback ?? itemAll[index].child,
+                  child: Transform.scale(
+                    scale: 0.9,
+                    child: Opacity(
+                      opacity: 0.8,
+                      child: SizedBox(
+                        width: itemAll[index].crossAxisCellCount! * itemCellWidth,
+                        height: itemAll[index].mainAxisCellCount! * itemCellHeight,
+                        child: Center(
+                          child: itemAll[index].feedback ?? itemAll[index].child,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/cutomer_multi_child_layout_view.dart
+++ b/lib/src/cutomer_multi_child_layout_view.dart
@@ -567,22 +567,21 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowRow(itemSize, columnH, columnLastH);
         if (insertIndex == -1) {
-          offsetX = 0;
+          offsetX = spacing;
           nowRowIndex = 0;
         } else {
-          offsetX = insertIndex * itemCellWidth +
-              (insertIndex >= 1 ? insertIndex : 0) * spacing;
+          offsetX = spacing + insertIndex * (itemCellWidth + spacing);
           nowRowIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemAll[i].id,
-          Offset(offsetX + spacing * 0.5, columnH[nowRowIndex])));
+          Offset(offsetX, columnH[nowRowIndex] + spacing)));
 
       // 修改x轴偏移量
-      offsetX += spacing +
-          itemCellWidth * (itemAll[i].crossAxisCellCount ?? 1) +
-          ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
+      offsetX += itemCellWidth * (itemAll[i].crossAxisCellCount ?? 1) +
+          ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing +
+          spacing;
 
       // 放置后修改当前行的index指向
       for (var c = 0; c < itemAll[i].crossAxisCellCount!; c++) {
@@ -704,22 +703,21 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowRow(itemSize, columnH, columnLastH);
         if (insertIndex == -1) {
-          offsetX = 0;
+          offsetX = spacing;
           nowRowIndex = 0;
         } else {
-          offsetX = insertIndex * itemCellWidth +
-              (insertIndex >= 1 ? insertIndex : 0) * spacing;
+          offsetX = spacing + insertIndex * (itemCellWidth + spacing);
           nowRowIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemChangeAll[i].id,
-          Offset(offsetX + spacing * 0.5, columnH[nowRowIndex])));
+          Offset(offsetX, columnH[nowRowIndex] + spacing)));
 
       // 修改x轴偏移量
-      offsetX += spacing +
-          itemCellWidth * (itemChangeAll[i].crossAxisCellCount ?? 1) +
-          ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
+      offsetX += itemCellWidth * (itemChangeAll[i].crossAxisCellCount ?? 1) +
+          ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing +
+          spacing;
 
       // 放置后修改当前行的index指向
       for (var c = 0; c < itemChangeAll[i].crossAxisCellCount!; c++) {
@@ -890,22 +888,21 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
-          offsetY = 0;
+          offsetY = spacing;
           nowColumIndex = 0;
         } else {
-          offsetY = insertIndex * itemCellHeight +
-              (insertIndex >= 1 ? insertIndex : 0) * spacing;
+          offsetY = spacing + insertIndex * (itemCellHeight + spacing);
           nowColumIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(
-          itemAll[i].id, Offset(rowW[nowColumIndex], offsetY + spacing * 0.5)));
+          itemAll[i].id, Offset(rowW[nowColumIndex] + spacing, offsetY)));
 
       // 修改y轴偏移量
-      offsetY += spacing +
-          itemCellHeight * (itemAll[i].crossAxisCellCount ?? 1) +
-          ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
+      offsetY += itemCellHeight * (itemAll[i].crossAxisCellCount ?? 1) +
+          ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing +
+          spacing;
 
       // 放置后修改当前行的index指向
       for (var c = 0; c < itemAll[i].mainAxisCellCount!; c++) {
@@ -996,22 +993,21 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
-          offsetY = 0;
+          offsetY = spacing;
           nowColumIndex = 0;
         } else {
-          offsetY = insertIndex * itemCellHeight +
-              (insertIndex >= 1 ? insertIndex : 0) * spacing;
+          offsetY = spacing + insertIndex * (itemCellHeight + spacing);
           nowColumIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemChangeAll[i].id,
-          Offset(rowW[nowColumIndex], offsetY + spacing * 0.5)));
+          Offset(rowW[nowColumIndex] + spacing, offsetY)));
 
       // 修改y轴偏移量
-      offsetY += spacing +
-          itemCellHeight * (itemChangeAll[i].crossAxisCellCount ?? 1) +
-          ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
+      offsetY += itemCellHeight * (itemChangeAll[i].crossAxisCellCount ?? 1) +
+          ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing +
+          spacing;
 
       // 放置后修改当前行的index指向
       for (var c = 0; c < itemChangeAll[i].mainAxisCellCount!; c++) {

--- a/lib/src/cutomer_multi_child_layout_view.dart
+++ b/lib/src/cutomer_multi_child_layout_view.dart
@@ -386,14 +386,14 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
         if (widget.scrollDirection == Axis.vertical) {
           _maxScrollWidth = constraints.maxWidth;
           var width = constraints.maxWidth;
-          itemCellWidth = (width - (widget.columnNum + 1) * widget.spacing) /
+          itemCellWidth = (width - (widget.columnNum - 1) * widget.spacing) /
               widget.columnNum;
           // 如果设置了固定高度，使用固定高度，否则使用宽度（正方形）
           itemCellHeight = widget.fixedCellHeight ?? itemCellWidth;
         } else {
           _maxScrollHeight = constraints.maxHeight;
           itemCellHeight =
-              (_maxScrollHeight - (widget.columnNum + 1) * widget.spacing) /
+              (_maxScrollHeight - (widget.columnNum - 1) * widget.spacing) /
                   widget.columnNum;
           // 水平滚动时保持正方形
           itemCellWidth = itemCellHeight;
@@ -573,16 +573,16 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowRow(itemSize, columnH, columnLastH);
         if (insertIndex == -1) {
-          offsetX = spacing;
+          offsetX = 0;
           nowRowIndex = 0;
         } else {
-          offsetX = spacing + insertIndex * (itemCellWidth + spacing);
+          offsetX = insertIndex * (itemCellWidth + spacing);
           nowRowIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemAll[i].id,
-          Offset(offsetX, columnH[nowRowIndex] + spacing)));
+          Offset(offsetX, columnH[nowRowIndex])));
 
       // 修改x轴偏移量
       offsetX += itemCellWidth * (itemAll[i].crossAxisCellCount ?? 1) +
@@ -709,16 +709,16 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowRow(itemSize, columnH, columnLastH);
         if (insertIndex == -1) {
-          offsetX = spacing;
+          offsetX = 0;
           nowRowIndex = 0;
         } else {
-          offsetX = spacing + insertIndex * (itemCellWidth + spacing);
+          offsetX = insertIndex * (itemCellWidth + spacing);
           nowRowIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemChangeAll[i].id,
-          Offset(offsetX, columnH[nowRowIndex] + spacing)));
+          Offset(offsetX, columnH[nowRowIndex])));
 
       // 修改x轴偏移量
       offsetX += itemCellWidth * (itemChangeAll[i].crossAxisCellCount ?? 1) +
@@ -894,16 +894,16 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
-          offsetY = spacing;
+          offsetY = 0;
           nowColumIndex = 0;
         } else {
-          offsetY = spacing + insertIndex * (itemCellHeight + spacing);
+          offsetY = insertIndex * (itemCellHeight + spacing);
           nowColumIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(
-          itemAll[i].id, Offset(rowW[nowColumIndex] + spacing, offsetY)));
+          itemAll[i].id, Offset(rowW[nowColumIndex], offsetY)));
 
       // 修改y轴偏移量
       offsetY += itemCellHeight * (itemAll[i].crossAxisCellCount ?? 1) +
@@ -999,16 +999,16 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       if (true) {
         int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
-          offsetY = spacing;
+          offsetY = 0;
           nowColumIndex = 0;
         } else {
-          offsetY = spacing + insertIndex * (itemCellHeight + spacing);
+          offsetY = insertIndex * (itemCellHeight + spacing);
           nowColumIndex = insertIndex;
         }
       }
 
       calculateItemPosition.add(ItemPosition(itemChangeAll[i].id,
-          Offset(rowW[nowColumIndex] + spacing, offsetY)));
+          Offset(rowW[nowColumIndex], offsetY)));
 
       // 修改y轴偏移量
       offsetY += itemCellHeight * (itemChangeAll[i].crossAxisCellCount ?? 1) +

--- a/lib/src/cutomer_multi_child_layout_view.dart
+++ b/lib/src/cutomer_multi_child_layout_view.dart
@@ -370,58 +370,63 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
 
   @override
   Widget build(BuildContext context) {
-    if (widget.scrollDirection == Axis.vertical) {
-      _maxScrollWidth = MediaQuery.of(context).size.width;
-      var width = MediaQuery.of(context).size.width;
-      itemCell =
-          (width - (widget.columnNum + 1) * widget.spacing) / widget.columnNum;
-    } else {
-      _maxScrollHeight = MediaQuery.of(context).size.height;
-      itemCell = (_maxScrollHeight - (widget.columnNum + 1) * widget.spacing) /
-          widget.columnNum;
-    }
-    return SingleChildScrollView(
-      key: _globalKey,
-      scrollDirection: widget.scrollDirection,
-      controller: _scrollController,
-      child: SizedBox(
-        height: _maxScrollHeight,
-        width: _maxScrollWidth,
-        child: CustomMultiChildLayout(
-          delegate: widget.scrollDirection == Axis.vertical
-              ? ProxyVerticalClass(
-                  itemAll,
-                  itemChangeAll,
-                  process,
-                  widget.columnNum,
-                  widget.spacing,
-                  itemCell, callback: (value) {
-                  if (value == _maxScrollHeight) return;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (widget.scrollDirection == Axis.vertical) {
+          _maxScrollWidth = constraints.maxWidth;
+          var width = constraints.maxWidth;
+          itemCell = (width - (widget.columnNum + 1) * widget.spacing) /
+              widget.columnNum;
+        } else {
+          _maxScrollHeight = constraints.maxHeight;
+          itemCell =
+              (_maxScrollHeight - (widget.columnNum + 1) * widget.spacing) /
+                  widget.columnNum;
+        }
+        return SingleChildScrollView(
+          key: _globalKey,
+          scrollDirection: widget.scrollDirection,
+          controller: _scrollController,
+          child: SizedBox(
+            height: _maxScrollHeight,
+            width: _maxScrollWidth,
+            child: CustomMultiChildLayout(
+              delegate: widget.scrollDirection == Axis.vertical
+                  ? ProxyVerticalClass(
+                      itemAll,
+                      itemChangeAll,
+                      process,
+                      widget.columnNum,
+                      widget.spacing,
+                      itemCell, callback: (value) {
+                      if (value == _maxScrollHeight) return;
 
-                  /// 需要强行刷新一下，防止滑动区域有问题
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    setState(() {
-                      _maxScrollHeight = value;
-                    });
-                  });
-                })
-              : ProxyHorizontalClass(
-                  itemAll,
-                  itemChangeAll,
-                  process,
-                  widget.columnNum,
-                  widget.spacing,
-                  itemCell, callback: (value) {
-                  /// 需要强行刷新一下，防止滑动区域有问题
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    setState(() {
-                      _maxScrollWidth = value;
-                    });
-                  });
-                }),
-          children: generateList(),
-        ),
-      ),
+                      /// 需要强行刷新一下，防止滑动区域有问题
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        setState(() {
+                          _maxScrollHeight = value;
+                        });
+                      });
+                    })
+                  : ProxyHorizontalClass(
+                      itemAll,
+                      itemChangeAll,
+                      process,
+                      widget.columnNum,
+                      widget.spacing,
+                      itemCell, callback: (value) {
+                      /// 需要强行刷新一下，防止滑动区域有问题
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        setState(() {
+                          _maxScrollWidth = value;
+                        });
+                      });
+                    }),
+              children: generateList(),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/src/cutomer_multi_child_layout_view.dart
+++ b/lib/src/cutomer_multi_child_layout_view.dart
@@ -21,6 +21,7 @@ class CustomerMultiChildView extends StatefulWidget {
   final double forwardRedundancy;
   final double backwardRedundancy;
   final double scrollStep;
+  final double? fixedCellHeight;
   final Function(List<int>)? onReorder;
   const CustomerMultiChildView(
     this.children,
@@ -35,6 +36,7 @@ class CustomerMultiChildView extends StatefulWidget {
     Key? key,
     this.collation = false,
     this.scrollDirection = Axis.vertical,
+    this.fixedCellHeight,
     this.onReorder,
   }) : super(key: key);
 
@@ -72,8 +74,11 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
 
   Timer? _timer;
 
-  /// 单元格大小
-  double itemCell = 0.0;
+  /// 单元格宽度
+  double itemCellWidth = 0.0;
+  
+  /// 单元格高度
+  double itemCellHeight = 0.0;
 
   @override
   void initState() {
@@ -285,8 +290,8 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                 child: DragTarget(
                   builder: (context, candidateData, rejectedData) {
                     return SizedBox(
-                      width: itemAll[index].crossAxisCellCount! * itemCell,
-                      height: itemAll[index].mainAxisCellCount! * itemCell,
+                      width: itemAll[index].crossAxisCellCount! * itemCellWidth,
+                      height: itemAll[index].mainAxisCellCount! * itemCellHeight,
                       child: Center(
                           child: dragItem == itemAll[index].trackingNumber
                               ? itemAll[index].placeholder ??
@@ -322,8 +327,8 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                 feedback: Material(
                   color: Colors.transparent,
                   child: SizedBox(
-                    width: itemAll[index].crossAxisCellCount! * itemCell,
-                    height: itemAll[index].mainAxisCellCount! * itemCell,
+                    width: itemAll[index].crossAxisCellCount! * itemCellWidth,
+                    height: itemAll[index].mainAxisCellCount! * itemCellHeight,
                     child: Center(
                       child: itemAll[index].feedback ?? itemAll[index].child,
                     ),
@@ -351,8 +356,8 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                 },
               )
             : SizedBox(
-                width: itemAll[index].crossAxisCellCount! * itemCell,
-                height: itemAll[index].mainAxisCellCount! * itemCell,
+                width: itemAll[index].crossAxisCellCount! * itemCellWidth,
+                height: itemAll[index].mainAxisCellCount! * itemCellHeight,
                 child: Center(child: itemAll[index].child),
               ));
   }
@@ -375,13 +380,17 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
         if (widget.scrollDirection == Axis.vertical) {
           _maxScrollWidth = constraints.maxWidth;
           var width = constraints.maxWidth;
-          itemCell = (width - (widget.columnNum + 1) * widget.spacing) /
+          itemCellWidth = (width - (widget.columnNum + 1) * widget.spacing) /
               widget.columnNum;
+          // 如果设置了固定高度，使用固定高度，否则使用宽度（正方形）
+          itemCellHeight = widget.fixedCellHeight ?? itemCellWidth;
         } else {
           _maxScrollHeight = constraints.maxHeight;
-          itemCell =
+          itemCellHeight =
               (_maxScrollHeight - (widget.columnNum + 1) * widget.spacing) /
                   widget.columnNum;
+          // 水平滚动时保持正方形
+          itemCellWidth = itemCellHeight;
         }
         return SingleChildScrollView(
           key: _globalKey,
@@ -398,7 +407,8 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                       process,
                       widget.columnNum,
                       widget.spacing,
-                      itemCell, callback: (value) {
+                      itemCellWidth,
+                      itemCellHeight, callback: (value) {
                       if (value == _maxScrollHeight) return;
 
                       /// 需要强行刷新一下，防止滑动区域有问题
@@ -414,7 +424,8 @@ class _CustomerMultiChildViewState extends State<CustomerMultiChildView>
                       process,
                       widget.columnNum,
                       widget.spacing,
-                      itemCell, callback: (value) {
+                      itemCellWidth,
+                      itemCellHeight, callback: (value) {
                       /// 需要强行刷新一下，防止滑动区域有问题
                       WidgetsBinding.instance.addPostFrameCallback((_) {
                         setState(() {
@@ -438,11 +449,12 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
   final double process;
   final int columnNum;
   final double spacing;
-  final double itemCell;
+  final double itemCellWidth;
+  final double itemCellHeight;
   final Function(double value)? callback;
 
   ProxyVerticalClass(this.itemAll, this.itemChangeAll, this.process,
-      this.columnNum, this.spacing, this.itemCell,
+      this.columnNum, this.spacing, this.itemCellWidth, this.itemCellHeight,
       {this.callback}) {
     // 累计每列的高度
     columnH = List.generate(columnNum, (index) {
@@ -471,14 +483,14 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
 
     // 判断本行是否都已经按行放满
     for (var indexX = 0; indexX < columnH.length; indexX++) {
-      if (columnH[indexX] - columnLastH[indexX] < itemCell) {
+      if (columnH[indexX] - columnLastH[indexX] < itemCellHeight) {
         // 判断当前点是否符合长度
-        int length = size.width ~/ itemCell;
+        int length = size.width ~/ itemCellWidth;
         if (columnH.length - indexX >= length) {
           insertIndex = indexX;
           for (var indexY = 0; indexY < length; indexY++) {
             if (columnH[indexY + indexX] - columnLastH[indexY + indexX] <
-                itemCell) {
+                itemCellHeight) {
             } else if (maxHeight - columnH[indexY + indexX] < size.height) {
               insertIndex = -1;
               break;
@@ -494,12 +506,12 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       // print("$indexX: $maxHeight - ${columnH[indexX]} >= ${size.height}");
       if (maxHeight - columnH[indexX] >= size.height) {
         // 判断当前点是否符合长度
-        int length = size.width ~/ itemCell;
+        int length = size.width ~/ itemCellWidth;
         if (columnH.length - indexX >= length) {
           insertIndex = indexX;
           for (var indexY = 0; indexY < length; indexY++) {
             if (columnH[indexY + indexX] - columnLastH[indexY + indexX] <
-                itemCell) {
+                itemCellHeight) {
             } else if (maxHeight - columnH[indexY + indexX] < size.height) {
               insertIndex = -1;
               break;
@@ -543,13 +555,13 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
       Size itemSize = layoutChild(
           itemAll[i].id,
           BoxConstraints(
-              minWidth: itemCell * (itemAll[i].crossAxisCellCount!) +
+              minWidth: itemCellWidth * (itemAll[i].crossAxisCellCount!) +
                   ((itemAll[i].crossAxisCellCount!) - 1) * spacing,
-              maxWidth: itemCell * (itemAll[i].crossAxisCellCount!) +
+              maxWidth: itemCellWidth * (itemAll[i].crossAxisCellCount!) +
                   ((itemAll[i].crossAxisCellCount!) - 1) * spacing,
-              minHeight: itemCell * (itemAll[i].mainAxisCellCount!) +
+              minHeight: itemCellHeight * (itemAll[i].mainAxisCellCount!) +
                   ((itemAll[i].mainAxisCellCount!) - 1) * spacing,
-              maxHeight: itemCell * (itemAll[i].mainAxisCellCount!) +
+              maxHeight: itemCellHeight * (itemAll[i].mainAxisCellCount!) +
                   ((itemAll[i].mainAxisCellCount!) - 1) * spacing));
 
       if (true) {
@@ -558,7 +570,7 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
           offsetX = 0;
           nowRowIndex = 0;
         } else {
-          offsetX = insertIndex * itemCell +
+          offsetX = insertIndex * itemCellWidth +
               (insertIndex >= 1 ? insertIndex : 0) * spacing;
           nowRowIndex = insertIndex;
         }
@@ -569,7 +581,7 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
 
       // 修改x轴偏移量
       offsetX += spacing +
-          itemCell * (itemAll[i].crossAxisCellCount ?? 1) +
+          itemCellWidth * (itemAll[i].crossAxisCellCount ?? 1) +
           ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
 
       // 放置后修改当前行的index指向
@@ -679,13 +691,13 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
     for (int i = 0; i < itemChangeAll.length; i++) {
       // 获取当前widget宽高限制
       Size itemSize = getSize(BoxConstraints(
-          minWidth: itemCell * (itemChangeAll[i].crossAxisCellCount!) +
+          minWidth: itemCellWidth * (itemChangeAll[i].crossAxisCellCount!) +
               ((itemChangeAll[i].crossAxisCellCount!) - 1) * spacing,
-          maxWidth: itemCell * (itemChangeAll[i].crossAxisCellCount!) +
+          maxWidth: itemCellWidth * (itemChangeAll[i].crossAxisCellCount!) +
               ((itemChangeAll[i].crossAxisCellCount!) - 1) * spacing,
-          minHeight: itemCell * (itemChangeAll[i].mainAxisCellCount!) +
+          minHeight: itemCellHeight * (itemChangeAll[i].mainAxisCellCount!) +
               ((itemChangeAll[i].mainAxisCellCount!) - 1) * spacing,
-          maxHeight: itemCell * (itemChangeAll[i].mainAxisCellCount!) +
+          maxHeight: itemCellHeight * (itemChangeAll[i].mainAxisCellCount!) +
               ((itemChangeAll[i].mainAxisCellCount!) - 1) * spacing));
 
       // 当前widget横向排布后越界处理
@@ -695,7 +707,7 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
           offsetX = 0;
           nowRowIndex = 0;
         } else {
-          offsetX = insertIndex * itemCell +
+          offsetX = insertIndex * itemCellWidth +
               (insertIndex >= 1 ? insertIndex : 0) * spacing;
           nowRowIndex = insertIndex;
         }
@@ -706,7 +718,7 @@ class ProxyVerticalClass extends MultiChildLayoutDelegate {
 
       // 修改x轴偏移量
       offsetX += spacing +
-          itemCell * (itemChangeAll[i].crossAxisCellCount ?? 1) +
+          itemCellWidth * (itemChangeAll[i].crossAxisCellCount ?? 1) +
           ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
 
       // 放置后修改当前行的index指向
@@ -729,11 +741,12 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
   final double process;
   final int columnNum;
   final double spacing;
-  final double itemCell;
+  final double itemCellWidth;
+  final double itemCellHeight;
   final Function(double value)? callback;
 
   ProxyHorizontalClass(this.itemAll, this.itemChangeAll, this.process,
-      this.columnNum, this.spacing, this.itemCell,
+      this.columnNum, this.spacing, this.itemCellWidth, this.itemCellHeight,
       {this.callback}) {
     // 累计每行的宽度
     rowW = List.generate(columnNum, (index) {
@@ -767,7 +780,7 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
   /// 判断当前列是否可以存放此widget,
   /// 查到后返回index > 0
   /// 未查到返回index = -1
-  int checkNowColumn(Size size, double itemCell, List rowW, List rowLastW) {
+  int checkNowColumn(Size size, List rowW, List rowLastW) {
     int insertIndex = -1;
     // 找到最大值
     double maxWidth = rowW.fold(
@@ -777,13 +790,13 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
 
     // 判断本列是否都已经按列放满
     for (var indexY = 0; indexY < rowW.length; indexY++) {
-      if (rowW[indexY] - rowLastW[indexY] < itemCell) {
+      if (rowW[indexY] - rowLastW[indexY] < itemCellHeight) {
         // 判断当前点是否符合长度
-        int length = size.height ~/ itemCell;
+        int length = size.height ~/ itemCellHeight;
         if (rowW.length - indexY >= length) {
           insertIndex = indexY;
           for (var indexX = 0; indexX < length; indexX++) {
-            if (rowW[indexY + indexX] - rowLastW[indexY + indexX] < itemCell) {
+            if (rowW[indexY + indexX] - rowLastW[indexY + indexX] < itemCellHeight) {
             } else if (maxWidth - rowW[indexY + indexX] < size.width) {
               insertIndex = -1;
               break;
@@ -799,11 +812,11 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       // print("$indexX: $maxHeight - ${columnH[indexX]} >= ${size.height}");
       if (maxWidth - rowW[indexY] >= size.width) {
         // 判断当前点是否符合长度
-        int length = size.height ~/ itemCell;
+        int length = size.height ~/ itemCellHeight;
         if (rowW.length - indexY >= length) {
           insertIndex = indexY;
           for (var indexX = 0; indexX < length; indexX++) {
-            if (rowW[indexY + indexX] - rowLastW[indexY + indexX] < itemCell) {
+            if (rowW[indexY + indexX] - rowLastW[indexY + indexX] < itemCellHeight) {
             } else if (maxWidth - rowW[indexY + indexX] < size.width) {
               insertIndex = -1;
               break;
@@ -864,23 +877,23 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
       Size itemSize = layoutChild(
           itemAll[i].id,
           BoxConstraints(
-              minWidth: itemCell * (itemAll[i].crossAxisCellCount!) +
+              minWidth: itemCellWidth * (itemAll[i].crossAxisCellCount!) +
                   ((itemAll[i].crossAxisCellCount!) - 1) * spacing,
-              maxWidth: itemCell * (itemAll[i].crossAxisCellCount!) +
+              maxWidth: itemCellWidth * (itemAll[i].crossAxisCellCount!) +
                   ((itemAll[i].crossAxisCellCount!) - 1) * spacing,
-              minHeight: itemCell * (itemAll[i].mainAxisCellCount!) +
+              minHeight: itemCellHeight * (itemAll[i].mainAxisCellCount!) +
                   ((itemAll[i].mainAxisCellCount!) - 1) * spacing,
-              maxHeight: itemCell * (itemAll[i].mainAxisCellCount!) +
+              maxHeight: itemCellHeight * (itemAll[i].mainAxisCellCount!) +
                   ((itemAll[i].mainAxisCellCount!) - 1) * spacing));
 
       // 当前widget竖排布后越界处理
       if (true) {
-        int insertIndex = checkNowColumn(itemSize, itemCell, rowW, rowLastW);
+        int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
           offsetY = 0;
           nowColumIndex = 0;
         } else {
-          offsetY = insertIndex * itemCell +
+          offsetY = insertIndex * itemCellHeight +
               (insertIndex >= 1 ? insertIndex : 0) * spacing;
           nowColumIndex = insertIndex;
         }
@@ -891,7 +904,7 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
 
       // 修改y轴偏移量
       offsetY += spacing +
-          itemCell * (itemAll[i].crossAxisCellCount ?? 1) +
+          itemCellHeight * (itemAll[i].crossAxisCellCount ?? 1) +
           ((itemAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
 
       // 放置后修改当前行的index指向
@@ -970,23 +983,23 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
     for (int i = 0; i < itemChangeAll.length; i++) {
       // 获取当前widget宽高限制
       Size itemSize = getSize(BoxConstraints(
-          minWidth: itemCell * (itemChangeAll[i].crossAxisCellCount!) +
+          minWidth: itemCellWidth * (itemChangeAll[i].crossAxisCellCount!) +
               ((itemChangeAll[i].crossAxisCellCount!) - 1) * spacing,
-          maxWidth: itemCell * (itemChangeAll[i].crossAxisCellCount!) +
+          maxWidth: itemCellWidth * (itemChangeAll[i].crossAxisCellCount!) +
               ((itemChangeAll[i].crossAxisCellCount!) - 1) * spacing,
-          minHeight: itemCell * (itemChangeAll[i].mainAxisCellCount!) +
+          minHeight: itemCellHeight * (itemChangeAll[i].mainAxisCellCount!) +
               ((itemChangeAll[i].mainAxisCellCount!) - 1) * spacing,
-          maxHeight: itemCell * (itemChangeAll[i].mainAxisCellCount!) +
+          maxHeight: itemCellHeight * (itemChangeAll[i].mainAxisCellCount!) +
               ((itemChangeAll[i].mainAxisCellCount!) - 1) * spacing));
 
       // 当前widget竖排布后越界处理
       if (true) {
-        int insertIndex = checkNowColumn(itemSize, itemCell, rowW, rowLastW);
+        int insertIndex = checkNowColumn(itemSize, rowW, rowLastW);
         if (insertIndex == -1) {
           offsetY = 0;
           nowColumIndex = 0;
         } else {
-          offsetY = insertIndex * itemCell +
+          offsetY = insertIndex * itemCellHeight +
               (insertIndex >= 1 ? insertIndex : 0) * spacing;
           nowColumIndex = insertIndex;
         }
@@ -997,7 +1010,7 @@ class ProxyHorizontalClass extends MultiChildLayoutDelegate {
 
       // 修改y轴偏移量
       offsetY += spacing +
-          itemCell * (itemChangeAll[i].crossAxisCellCount ?? 1) +
+          itemCellHeight * (itemChangeAll[i].crossAxisCellCount ?? 1) +
           ((itemChangeAll[i].crossAxisCellCount ?? 1) - 1) * spacing;
 
       // 放置后修改当前行的index指向

--- a/lib/src/staggered_reorderable_view.dart
+++ b/lib/src/staggered_reorderable_view.dart
@@ -44,6 +44,10 @@ class StaggeredReorderableView extends StatelessWidget {
   /// 每次自动滚动长度，默认10.0
   final double scrollStep;
 
+  /// 固定的单元格高度（仅对垂直滚动生效）
+  /// 如果设置此值，单元格将不再是正方形，而是固定高度，宽度根据列数自适应
+  final double? fixedCellHeight;
+
   /// 每次交换完会调用此方法，获取排序后的trackingNumber列表
   final Function(List<int>)? onReorder;
 
@@ -67,6 +71,8 @@ class StaggeredReorderableView extends StatelessWidget {
   ///
   /// [scrollStep] : 每次自动滚动长度.
   ///
+  /// [fixedCellHeight] : 固定的单元格高度（仅对垂直滚动生效），设置后单元格不再是正方形.
+  ///
   const StaggeredReorderableView.customer(
       {Key? key,
       required List<ReorderableItem> children,
@@ -80,6 +86,7 @@ class StaggeredReorderableView extends StatelessWidget {
       double forwardRedundancy = 40.0,
       double backwardRedundancy = 40.0,
       double scrollStep = 10.0,
+      double? fixedCellHeight,
       Function(List<int>)? onReorder})
       : this(
             key: key,
@@ -94,6 +101,7 @@ class StaggeredReorderableView extends StatelessWidget {
             forwardRedundancy: forwardRedundancy,
             backwardRedundancy: backwardRedundancy,
             scrollStep: scrollStep,
+            fixedCellHeight: fixedCellHeight,
             onReorder: onReorder);
 
   const StaggeredReorderableView({
@@ -109,6 +117,7 @@ class StaggeredReorderableView extends StatelessWidget {
     required this.forwardRedundancy,
     required this.backwardRedundancy,
     required this.scrollStep,
+    this.fixedCellHeight,
     this.onReorder,
   }) : super(key: key);
 
@@ -126,6 +135,7 @@ class StaggeredReorderableView extends StatelessWidget {
         scrollStep,
         collation: collation,
         scrollDirection: scrollDirection,
+        fixedCellHeight: fixedCellHeight,
         onReorder: onReorder);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: staggered_reorderable
-description: 可拖拽的不规则瀑布流排序
+description: staggered_reorderable
 version: 0.0.14
 homepage: https://github.com/jingluoguo/staggered_reorderable
 


### PR DESCRIPTION
当前计算宽度时,使用的是窗口宽度
如果在组件外部有padding时,计算的宽度偏大,会导致溢出

如,这里在左侧添加了20的padding.
<img width="595" height="745" alt="Screenshot 2025-11-10 at 16 35 11" src="https://github.com/user-attachments/assets/ddb4d428-4ecd-4b8a-b112-f0780bc9b759" />

以下是本pr修复的结果
<img width="595" height="745" alt="Screenshot 2025-11-10 at 16 35 26" src="https://github.com/user-attachments/assets/6759241d-0740-4fee-bee5-7ca51291b1bc" />
